### PR TITLE
chore(mise): add golangci-lint

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,8 @@
 go = "1.25"
 node = "24"
 uv = "latest"
+golangci-lint = "2"
 
 [env]
 SEED_DEVELOPMENT_DB="1"
+LOG_LEVEL="DEBUG"


### PR DESCRIPTION
golangci-lint didn't have its version specified anywhere. Add it to mise.toml
