### PR TITLE
GitHub Actions maintenance: conditional tests, failure issues, uv upgrade

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,8 +5,33 @@ on:
   pull_request:
 
 jobs:
+  changes:
+    name: "Detect changes"
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'server/**'
+              - 'cmd/**'
+              - 'schema.sql'
+              - 'go.mod'
+              - 'go.sum'
+              - 'justfile'
+            frontend:
+              - 'client/**'
+              - 'justfile'
+
   ci:
     name: "golang CI"
+    needs: changes
+    if: github.ref == 'refs/heads/main' || needs.changes.outputs.backend == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -30,6 +55,9 @@ jobs:
           version: v2.8.0
 
   js-ci:
+    name: "frontend CI"
+    needs: changes
+    if: github.ref == 'refs/heads/main' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -10,6 +10,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  issues: write
 
 # Allow only one concurrent deployment
 concurrency:
@@ -34,7 +35,7 @@ jobs:
           node-version: "24"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install Pandoc
         run: sudo apt-get install -y pandoc
@@ -52,6 +53,45 @@ jobs:
         uses: actions/upload-pages-artifact@v4
         with:
           path: docs/site
+
+      - name: Create or update issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = 'Site build failed';
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = `The site build failed. See the [workflow run](${runUrl}) for details.`;
+
+            // Check for existing open issue with this title
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            const existingIssue = issues.find(issue => issue.title === title);
+
+            if (existingIssue) {
+              // Add a comment to the existing issue
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingIssue.number,
+                body: body
+              });
+              console.log(`Added comment to existing issue #${existingIssue.number}`);
+            } else {
+              // Create a new issue
+              const { data: newIssue } = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                body: body
+              });
+              console.log(`Created new issue #${newIssue.number}`);
+            }
 
   deploy:
     environment:


### PR DESCRIPTION
## Changes

### `.github/workflows/pages.yaml`
- **Upgraded setup-uv** from v5 to v7
- **Added issue creation on failure**: When the site build fails, it will:
  - Search for an existing open issue titled "Site build failed"
  - If found, add a comment with the workflow run link
  - If not found, create a new issue with the workflow run link

### `.github/workflows/ci.yaml`
- **Added path filtering for PRs** using `dorny/paths-filter@v3`:
  - Backend tests run when: `server/**`, `cmd/**`, `schema.sql`, `go.mod`, `go.sum`, or `justfile` change
  - Frontend tests run when: `client/**` or `justfile` change
  - E2E tests always run
- **All tests always run on pushes to main** (safety net)